### PR TITLE
Changes for hindi lpp validation

### DIFF
--- a/conllulex/config.py
+++ b/conllulex/config.py
@@ -73,6 +73,9 @@ LANG_CFG = {
             ("p.Locus", "p.Goal"),
             ("p.Locus", "p.Source"),
             ("p.Characteristic", "p.Stuff"),
+            ("p.Characteristic", "p.QuantityValue"),
+            ("p.PartPortion", "p.Characteristic"),
+            ("p.Gestalt", "p.Whole"),
             ("p.Whole", "p.Gestalt"),
             ("p.Org", "p.Gestalt"),
             ("p.QuantityItem", "p.Gestalt"),
@@ -130,10 +133,13 @@ LANG_CFG = {
         },
         # Like above, but for lambdas applied to individual lemmas. All lambdas will be applied to both
         # the lexlemma computed from each token's lemma and the given lexlemma.
+
+        # undoing and commenting out.
+
         "mwe_lexlemma_mismatch_xforms": [
-            lambda lemma: lemma.replace("़", ""),
-            lambda lemma: lemma.replace("ँ", "ं"),
-            lambda lemma: lemma.replace("ख्य", "खय"),
+        #    lambda lemma: lemma.replace("़", ""),
+        #    lambda lemma: lemma.replace("ँ", "ं"),
+        #    lambda lemma: lemma.replace("ख्य", "खय"),
         ],
     },
     "zh": {

--- a/conllulex/config.py
+++ b/conllulex/config.py
@@ -193,6 +193,8 @@ LANG_CFG = {
         "extra_prepositional_supersenses": set(),
         "mwe_lexlemma_mismatch_whitelist": {},
         "mwe_lexlemma_mismatch_xforms": [],
+        "mwe_lexlemma_validation_column": "lemma",
+        "lexcat_exception_list":{}, # skip invalid supersense check for this list of lexcats
     },
 }
 

--- a/conllulex/config.py
+++ b/conllulex/config.py
@@ -64,6 +64,8 @@ LANG_CFG = {
         "extra_prepositional_supersenses": set(),
         "mwe_lexlemma_mismatch_whitelist": {},
         "mwe_lexlemma_mismatch_xforms": [],
+        "mwe_lexlemma_validation_column": "lemma",
+        "lexcat_exception_list":{} # skip invalid supersense check for this list of lexcats
     },
     # Hindi
     "hi": {
@@ -141,6 +143,8 @@ LANG_CFG = {
         #    lambda lemma: lemma.replace("ँ", "ं"),
         #    lambda lemma: lemma.replace("ख्य", "खय"),
         ],
+        "mwe_lexlemma_validation_column": "word",
+        "lexcat_exception_list":{'PRON','PART'}, # skip invalid supersense check for this list of lexcats
     },
     "zh": {
         "permitted_ancestor_combos": {

--- a/conllulex/conllulex_to_json.py
+++ b/conllulex/conllulex_to_json.py
@@ -457,16 +457,13 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
         lex_exprs_to_validate = chain(sentence["swes"].values(), sentence["smwes"].values()) if validate_type else []
         for lex_expr in lex_exprs_to_validate:
 
-
-            if corpus_config['language'] == 'hi' and len(lex_expr['toknums']) > 1:
+            if len(lex_expr['toknums']) > 1:
                 # check against the form directly for hindi MWE expressions only
                 assert_(
-                    lex_expr["lexlemma"] == " ".join(sentence["toks"][i - 1]["word"] for i in lex_expr["toknums"]),
+                    lex_expr["lexlemma"] == " ".join(sentence["toks"][i - 1][lang_config['mwe_lexlemma_validation_column']] for i in lex_expr["toknums"]),
                     f"MWE lemma is incorrect: {lex_expr} vs. {sentence['toks'][lex_expr['toknums'][0] - 1]}",
                     token=lex_expr,
                 )
-
-
             else:
                 assert_(
                     lex_expr["lexlemma"] == " ".join(sentence["toks"][i - 1]["lemma"] for i in lex_expr["toknums"]),
@@ -500,11 +497,9 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
                 elif ss is None:
                     assert_(False, f"Missing supersense annotation in lexical entry: {lex_expr}", token=lex_expr)
                 elif ss not in valid_ss:
-                    if corpus_config['language'] == 'hi':
-                        if lexcat not in ['PRON','PART']:
-                            assert_(False, f"Invalid supersense(s) in lexical entry: {lex_expr}", token=lex_expr)
-                    else:
+                    if lexcat not in lang_config['lexcat_exception_list']:
                         assert_(False, f"Invalid supersense(s) in lexical entry: {lex_expr}", token=lex_expr)
+
                 elif (lexcat in ("N", "V") or lexcat.startswith("V.")) and ss2 is not None:
                     assert_(False, f"Noun/verb should not have ss2 annotation: {lex_expr}", token=lex_expr)
                 elif ss2 is not None and ss2 not in valid_ss:
@@ -527,16 +522,9 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
                             assert_(ss not in ss2_ancestors, f"unexpected construal: {ss} ~> {ss2}", token=lex_expr)
                             assert_(ss2 not in ss_ancestors, f"unexpected construal: {ss} ~> {ss2}", token=lex_expr)
             else:
-                if corpus_config['language'] == 'hi':
+                if lexcat not in lang_config['lexcat_exception_list']:
                     # PRON and PART get supersense labels, but not all of them. Only irregular pronouns and some FOCUS-related particles.
                     # No easy solution for irregular pronouns. Focus particles TBD in v2.7 guidelines.
-                    if lexcat not in ('PRON','PART'):
-                        assert_(
-                            ss is None and ss2 is None and lexcat not in ("P", "INF.P", "PP", "POSS", "PRON.POSS"),
-                            f"Invalid supersense(s) in lexical entry",
-                            token=lex_expr,
-                        )
-                else:
                     assert_(
                         ss is None and ss2 is None and lexcat not in ("P", "INF.P", "PP", "POSS", "PRON.POSS"),
                         f"Invalid supersense(s) in lexical entry",

--- a/conllulex/lexcatter.py
+++ b/conllulex/lexcatter.py
@@ -1,7 +1,7 @@
 from conllulex.supersenses import NSS, VSS, PSS
 
 
-def supersenses_for_lexcat(lc,language_code = None):
+def supersenses_for_lexcat(lc):
 
     if lc == "N":
         return NSS
@@ -23,22 +23,6 @@ def supersenses_for_lexcat(lc,language_code = None):
         return PSS
     if lc in ("POSS", "PRON.POSS"):
         return PSS | {"`$"}
-
-    # irregular pronouns in hindi marked for oblique case and with an inflection in place of the post-position (See Yamuna Kachru's Hindi grammar book, section on pronouns).
-    # it's not clear always that a post-position should be extracted from the morphology; i couldn't find any theory for irregular genitive pronouns, though there is some backing for extracting accusative/dative postpositions into a separate token out of the irregular pronoun
-    # And so, all irregular pronouns marked with oblique case and inflected get the prepositional SNACS label. Any feedback appreciated :)
-    if language_code == 'hi' and lc == 'PRON':
-        return PSS
-
-    # PARTicles have been annotated with preposition supersenses. Particles UPOS was determined by UD parsing. May need to revisit in v2.7
-    if language_code == 'hi' and lc == 'PART':
-        PSS.add('p.Focus') #to revisit - version 2.7
-        PSS.add('p.`d')  # to revisit - version 2.7
-        PSS.add('p.`i')  # to revisit - version 2.7
-        return PSS
-
-
-
 
 
 BASE_LEXCATS = {
@@ -67,8 +51,6 @@ BASE_LEXCATS = {
 
 HI_LEXCATS = BASE_LEXCATS
 HI_LEXCATS.add('PART')
-HI_LEXCATS.add('`d')
-HI_LEXCATS.add('`i')
 
 ZH_LEXCATS = {
     "BA", # 把

--- a/conllulex/lexcatter.py
+++ b/conllulex/lexcatter.py
@@ -1,7 +1,8 @@
 from conllulex.supersenses import NSS, VSS, PSS
 
 
-def supersenses_for_lexcat(lc):
+def supersenses_for_lexcat(lc,language_code = None):
+
     if lc == "N":
         return NSS
     if lc == "V" or lc.startswith("V."):
@@ -16,9 +17,28 @@ def supersenses_for_lexcat(lc):
             }, lc  # PARSEME 1.1 verbal MWE subtypes
         return VSS
     if lc in ("P", "PP", "INF.P"):
+        PSS.add('p.Focus')  # to revisit - version 2.7
+        PSS.add('p.`d')  # to revisit - version 2.7
+        PSS.add('p.`i')  # to revisit - version 2.7
         return PSS
     if lc in ("POSS", "PRON.POSS"):
         return PSS | {"`$"}
+
+    # irregular pronouns in hindi marked for oblique case and with an inflection in place of the post-position (See Yamuna Kachru's Hindi grammar book, section on pronouns).
+    # it's not clear always that a post-position should be extracted from the morphology; i couldn't find any theory for irregular genitive pronouns, though there is some backing for extracting accusative/dative postpositions into a separate token out of the irregular pronoun
+    # And so, all irregular pronouns marked with oblique case and inflected get the prepositional SNACS label. Any feedback appreciated :)
+    if language_code == 'hi' and lc == 'PRON':
+        return PSS
+
+    # PARTicles have been annotated with preposition supersenses. Particles UPOS was determined by UD parsing. May need to revisit in v2.7
+    if language_code == 'hi' and lc == 'PART':
+        PSS.add('p.Focus') #to revisit - version 2.7
+        PSS.add('p.`d')  # to revisit - version 2.7
+        PSS.add('p.`i')  # to revisit - version 2.7
+        return PSS
+
+
+
 
 
 BASE_LEXCATS = {
@@ -44,6 +64,11 @@ BASE_LEXCATS = {
     "PUNCT",
     "X",
 }
+
+HI_LEXCATS = BASE_LEXCATS
+HI_LEXCATS.add('PART')
+HI_LEXCATS.add('`d')
+HI_LEXCATS.add('`i')
 
 ZH_LEXCATS = {
     "BA", # 把
@@ -74,4 +99,6 @@ ZH_LEXCATS = {
 def get_lexcat_set(language_code):
     if language_code == "zh":
         return ZH_LEXCATS
+    if language_code == 'hi':
+        return HI_LEXCATS
     return BASE_LEXCATS

--- a/conllulex/lexcatter.py
+++ b/conllulex/lexcatter.py
@@ -1,5 +1,5 @@
 from conllulex.supersenses import NSS, VSS, PSS
-
+from copy import deepcopy
 
 def supersenses_for_lexcat(lc):
 
@@ -49,7 +49,7 @@ BASE_LEXCATS = {
     "X",
 }
 
-HI_LEXCATS = BASE_LEXCATS
+HI_LEXCATS = deepcopy(BASE_LEXCATS)
 HI_LEXCATS.add('PART')
 
 ZH_LEXCATS = {

--- a/conllulex/lexcatter.py
+++ b/conllulex/lexcatter.py
@@ -17,10 +17,7 @@ def supersenses_for_lexcat(lc):
             }, lc  # PARSEME 1.1 verbal MWE subtypes
         return VSS
     if lc in ("P", "PP", "INF.P"):
-        PSS.add('p.Focus')  # to revisit - version 2.7
-        PSS.add('p.`d')  # to revisit - version 2.7
-        PSS.add('p.`i')  # to revisit - version 2.7
-        return PSS
+        return PSS | {"p.Focus","p.`d","p.`i"}
     if lc in ("POSS", "PRON.POSS"):
         return PSS | {"`$"}
 


### PR DESCRIPTION
Summary of changes:
1. Allow supersenses for PRON and PART lexcats. This supports annotations for irregular pronouns (mera/meri, tumhare, apna/apni etc) which don't have a clean theory which extracts the postposition from the irregular pronoun token (unlike, say, uska, uski, uske). This is done for hindi language only via configuration.
2. Create an exception preventing supersense checks on PRON and PART lexcats, as not all Pronouns and Particles have supersense labels. This is restricted to hindi language only. 
3. Allow supersenses on PART lexcats like [to, bhi, hi]. 
4. Create a new PART lexcat for particles (except negation: nahin, na which uses ADV lexcat) (hindi language only via configuration)
5. Add FOCUS, [ ``d, `i] to the list of allowed supersenses for lexcat = P (hindi language only)
6. MWE lexlemmas are checked against the token directly and not the lemma. This is in line with certain MWE cases like 'ki tarah', 'ke/ki upar' - I don't think 'ka tarah' or 'ka upar' exists as an MWE yet the lemmatized form of ki and ke is always ka. This is added via configuration for hindi language only.

2,3,4,5 can potentially be revisited with the new v2.7 guidelines which looks at FOCUS labels for English. 

