### PR TITLE
New labels for SNACS v2.6, and changes for MWEs with a goeswith relation

### DIFF
--- a/conllulex/config.py
+++ b/conllulex/config.py
@@ -65,6 +65,7 @@ LANG_CFG = {
         "mwe_lexlemma_mismatch_whitelist": {},
         "mwe_lexlemma_mismatch_xforms": [],
         "mwe_lexlemma_validation_column": "lemma",
+        "mwe_lemma_exception_lexcat_list": set(),
         "lexcat_exception_list":{} # skip invalid supersense check for this list of lexcats
     },
     # Hindi
@@ -110,8 +111,9 @@ LANG_CFG = {
             ("PART", "P"),  # से
         },
         "mismatched_lexcat_exception_checks": [
-            lambda d: (d["lexcat"] == "P" and d["upos"] == "PRON"),  # possessive pronouns
-            lambda d: (d["lexcat"] == "ADV" and d["upos"] == "PART"),  # ही
+            lambda d: (d["lexcat"] == "P" and d["upos"] in ("SCONJ",'PART','ADJ','ADV')),
+            lambda d: (d["lexcat"] in ("PRON.NOM",'PRON.OBL','PRON.WH','PRON.REFL') and d["upos"] == "PRON"),
+            lambda d: (d["lexcat"] in ('ADV','PART.FOC') and d["upos"] == "PART"),
         ],
         # TODO is this really needed? These probably ought to just live in supersenses.py
         "extra_prepositional_supersenses": {"p.Focus", "p.NONSNACS"},
@@ -119,19 +121,19 @@ LANG_CFG = {
         # the first item is the lemma and the second item is a list of forms which are
         # acceptable lexlemmas for that lemma.
         "mwe_lexlemma_mismatch_whitelist": {
-            "का": ["के", "की"],
-            "मैं": ["के", "की"],
-            "हम": ["के", "की", "में", "से", "को"],
-            "तू": ["के", "की", "में", "से", "को"],
-            "तुम": ["के", "की", "में", "से", "को"],
-            "आप": ["के", "की", "में", "से", "को"],
-            "वह": ["के", "की", "में", "से", "को"],
-            "यह": ["के", "की", "में", "से", "को"],
-            "वे": ["के", "की", "में", "से", "को"],
-            "ये": ["के", "की", "में", "से", "को"],
-            "अपना": ["के", "की", "में", "से", "को"],
-            "जो": ["के", "की", "में", "से", "को"],
-            "सबसे": ["से"],
+            #"का": ["के", "की"],
+            #"मैं": ["के", "की"],
+            #"हम": ["के", "की", "में", "से", "को"],
+            #"तू": ["के", "की", "में", "से", "को"],
+            #"तुम": ["के", "की", "में", "से", "को"],
+            #"आप": ["के", "की", "में", "से", "को"],
+            #"वह": ["के", "की", "में", "से", "को"],
+            #"यह": ["के", "की", "में", "से", "को"],
+            #"वे": ["के", "की", "में", "से", "को"],
+            #"ये": ["के", "की", "में", "से", "को"],
+            #"अपना": ["के", "की", "में", "से", "को"],
+            #"जो": ["के", "की", "में", "से", "को"],
+            #"सबसे": ["से"],
         },
         # Like above, but for lambdas applied to individual lemmas. All lambdas will be applied to both
         # the lexlemma computed from each token's lemma and the given lexlemma.
@@ -144,7 +146,8 @@ LANG_CFG = {
         #    lambda lemma: lemma.replace("ख्य", "खय"),
         ],
         "mwe_lexlemma_validation_column": "word",
-        "lexcat_exception_list":{'PRON','PART'}, # skip invalid supersense check for this list of lexcats
+        "mwe_lemma_exception_lexcat_list": {"PRON"},
+        "lexcat_exception_list":{}, # skip invalid supersense check for this list of lexcats
     },
     "zh": {
         "permitted_ancestor_combos": {
@@ -194,6 +197,7 @@ LANG_CFG = {
         "mwe_lexlemma_mismatch_whitelist": {},
         "mwe_lexlemma_mismatch_xforms": [],
         "mwe_lexlemma_validation_column": "lemma",
+        "mwe_lemma_exception_lexcat_list": set(),
         "lexcat_exception_list":{}, # skip invalid supersense check for this list of lexcats
     },
 }

--- a/conllulex/conllulex_to_json.py
+++ b/conllulex/conllulex_to_json.py
@@ -131,7 +131,7 @@ def _store_morph_and_deps(token_dict, token, errors, is_ellipsis, is_supertoken,
         token_dict["deprel"] = None
 
 
-def _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper,corpus='streusle'):
+def _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper,corpus):
     sent_id = sentence["sent_id"]
     token_num = token_dict["#"]
 

--- a/conllulex/conllulex_to_json.py
+++ b/conllulex/conllulex_to_json.py
@@ -131,7 +131,7 @@ def _store_morph_and_deps(token_dict, token, errors, is_ellipsis, is_supertoken,
         token_dict["deprel"] = None
 
 
-def _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper):
+def _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper,corpus='streusle'):
     sent_id = sentence["sent_id"]
     token_num = token_dict["#"]
 
@@ -181,12 +181,14 @@ def _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper):
             )
     else:
         token_dict["smwe"] = None
-        _append_if_error(
-            errors,
-            sent_id,
-            token["lexlemma"] == token["lemma"],
-            f"Single-word expression lemma \"{token['lexlemma']}\" doesn't match token lemma \"{token['lemma']}\"",
-            token=token,
+        lang_config, _ = get_config(corpus)
+        if token['upos'] not in lang_config['mwe_lemma_exception_lexcat_list']:
+            _append_if_error(
+                errors,
+                sent_id,
+                token["lexlemma"] == token["lemma"],
+                f"Single-word expression lemma \"{token['lexlemma']}\" doesn't match token lemma \"{token['lemma']}\"",
+                token=token,
         )
         sentence["swes"][token_num]["lexlemma"] = token["lexlemma"]
         _append_if_error(errors, sent_id, token["lexcat"] != "_", f"SWE token must have lexcat.", token=token)
@@ -246,7 +248,9 @@ def _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper):
             token=token,
         )
 
+
     lextag = token["lextag"]
+
     for m in re.finditer(r"\b[a-z]\.[A-Za-z/-]+", token["lextag"]):
         lextag = lextag.replace(m.group(0), ss_mapper(m.group(0)))
     for m in re.finditer(r"\b([a-z]\.[A-Za-z/-]+)\|\1\b", lextag):
@@ -375,7 +379,7 @@ def _load_sentences(
                     token_dict[nullable_column] = None
 
             if not is_ellipsis and not is_supertoken:
-                _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper)
+                _store_conllulex_columns(sentence, token_dict, token, errors, ss_mapper,corpus)
                 sentence["toks"].append(token_dict)
             elif is_ellipsis:
                 sentence["etoks"].append(token_dict)
@@ -417,7 +421,7 @@ def _mwe_lexlemma_valid(lang_config, sentence, smwe):
             value = xform(value)
         return value
 
-    possible_lexlemmas = {" ".join(apply_xforms(xforms, sentence["toks"][i - 1]["lemma"]) for i in smwe["toknums"] if sentence["toks"][i - 1]["lemma"] != '_')}
+    possible_lexlemmas = {" ".join(apply_xforms(xforms, sentence["toks"][i - 1][lang_config['mwe_lexlemma_validation_column']]) for i in smwe["toknums"] if sentence["toks"][i - 1]["lemma"] != '_')}
 
     for lemma, mismatched_lexlemmas in lang_config["mwe_lexlemma_mismatch_whitelist"].items():
         for mismatched_lexlemma in mismatched_lexlemmas:
@@ -434,7 +438,12 @@ def _mwe_lexlemma_valid(lang_config, sentence, smwe):
             )
 
     xformed_lexlemma = " ".join(apply_xforms(xforms, x) for x in smwe["lexlemma"].split(" "))
-    return xformed_lexlemma in possible_lexlemmas, possible_lexlemmas, xformed_lexlemma
+    if sentence['toks'][smwe['toknums'][0] - 1]['upos'] in lang_config['mwe_lemma_exception_lexcat_list']: # exception for Hindi Pronouns
+        correct = True
+    else:
+        correct = xformed_lexlemma in possible_lexlemmas
+
+    return correct, possible_lexlemmas, xformed_lexlemma
 
 
 def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validate_type, override_mwe_render):
@@ -463,18 +472,20 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
 
             if len(lex_expr['toknums']) > 1:
                 # check against the form directly for hindi MWE expressions only
-                assert_(
-                    lex_expr["lexlemma"] == " ".join(sentence["toks"][i - 1][lang_config['mwe_lexlemma_validation_column']] for i in lex_expr["toknums"] if sentence["toks"][i - 1][lang_config['mwe_lexlemma_validation_column']] != '_' ),
-                    f"MWE lemma is incorrect: {lex_expr} vs. {sentence['toks'][lex_expr['toknums'][0] - 1]}",
-                    token=lex_expr,
+                if lex_expr["lexcat"] not in lang_config['mwe_lemma_exception_lexcat_list']:
+                    assert_(
+                        lex_expr["lexlemma"] == " ".join(sentence["toks"][i - 1][lang_config['mwe_lexlemma_validation_column']] for i in lex_expr["toknums"] if sentence["toks"][i - 1][lang_config['mwe_lexlemma_validation_column']] != '_' ),
+                        f"MWE lemma is incorrect: {lex_expr} vs. {sentence['toks'][lex_expr['toknums'][0] - 1]}",
+                        token=lex_expr,
 
-                )
+                    )
             else:
-                assert_(
-                    lex_expr["lexlemma"] == " ".join(sentence["toks"][i - 1]["lemma"] for i in lex_expr["toknums"]),
-                    f"MWE lemma is incorrect: {lex_expr} vs. {sentence['toks'][lex_expr['toknums'][0] - 1]}",
-                    token=lex_expr,
-                )
+                if lex_expr["lexcat"] not in lang_config['mwe_lemma_exception_lexcat_list']:
+                    assert_(
+                        lex_expr["lexlemma"] == " ".join(sentence["toks"][i - 1]["lemma"] for i in lex_expr["toknums"]),
+                        f"MWE lemma is incorrect: {lex_expr} vs. {sentence['toks'][lex_expr['toknums'][0] - 1]}",
+                        token=lex_expr,
+                    )
             lexcat = lex_expr["lexcat"]
             if lexcat.endswith("!@"):
                 lexcat_tbd_count += 1
@@ -486,9 +497,10 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
             elif lexcat in ["P", "PP"] and "P" not in corpus_config["supersense_annotated"]:
                 valid_ss = set()
             else:
-                valid_ss = supersenses_for_lexcat(lexcat)
+                valid_ss = supersenses_for_lexcat(lexcat,corpus_config['language'])
                 if lexcat in ["P", "PP"] and "P" in corpus_config["supersense_annotated"]:
                     valid_ss = valid_ss | lang_config["extra_prepositional_supersenses"]
+
             if "V" in corpus_config["supersense_annotated"] and lexcat == "V":
                 assert_(
                     len(lex_expr["toknums"]) == 1,
@@ -502,6 +514,8 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
                 elif ss is None:
                     assert_(False, f"Missing supersense annotation in lexical entry: {lex_expr}", token=lex_expr)
                 elif ss not in valid_ss:
+                    if sent_id == 'lp_hi_26-73':
+                        print ('here')
                     if lexcat not in lang_config['lexcat_exception_list']:
                         assert_(False, f"Invalid supersense(s) in lexical entry: {lex_expr}", token=lex_expr)
 
@@ -528,8 +542,6 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
                             assert_(ss2 not in ss_ancestors, f"unexpected construal: {ss} ~> {ss2}", token=lex_expr)
             else:
                 if lexcat not in lang_config['lexcat_exception_list']:
-                    # PRON and PART get supersense labels, but not all of them. Only irregular pronouns and some FOCUS-related particles.
-                    # No easy solution for irregular pronouns. Focus particles TBD in v2.7 guidelines.
                     assert_(
                         ss is None and ss2 is None and lexcat not in ("P", "INF.P", "PP", "POSS", "PRON.POSS"),
                         f"Invalid supersense(s) in lexical entry",
@@ -578,6 +590,7 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
 
             assert_(len(smwe["toknums"]) > 1, "SMWEs must have more than one token", token=smwe)
             correct, possible_lexlemmas, xformed_lexlemma = _mwe_lexlemma_valid(lang_config, sentence, smwe)
+
             assert_(
                 correct,
                 "lexlemma appears incorrect for smwe",

--- a/conllulex/conllulex_to_json.py
+++ b/conllulex/conllulex_to_json.py
@@ -514,8 +514,6 @@ def _validate_sentences(corpus, sentences, errors, validate_upos_lextag, validat
                 elif ss is None:
                     assert_(False, f"Missing supersense annotation in lexical entry: {lex_expr}", token=lex_expr)
                 elif ss not in valid_ss:
-                    if sent_id == 'lp_hi_26-73':
-                        print ('here')
                     if lexcat not in lang_config['lexcat_exception_list']:
                         assert_(False, f"Invalid supersense(s) in lexical entry: {lex_expr}", token=lex_expr)
 

--- a/conllulex/lexcatter.py
+++ b/conllulex/lexcatter.py
@@ -1,7 +1,7 @@
 from conllulex.supersenses import NSS, VSS, PSS
 from copy import deepcopy
 
-def supersenses_for_lexcat(lc):
+def supersenses_for_lexcat(lc,language=None):
 
     if lc == "N":
         return NSS
@@ -16,10 +16,12 @@ def supersenses_for_lexcat(lc):
                 "V.IAV",
             }, lc  # PARSEME 1.1 verbal MWE subtypes
         return VSS
-    if lc in ("P", "PP", "INF.P"):
+    if lc in ("P", "PP", "INF.P","PART.FOC"):
         return PSS | {"p.Focus","p.`d","p.`i"}
     if lc in ("POSS", "PRON.POSS"):
         return PSS | {"`$"}
+    if lc == 'PRON' and language == 'hi': # for Hindi
+        return PSS | {"p.Focus",'p.`d'}
 
 
 BASE_LEXCATS = {
@@ -48,6 +50,11 @@ BASE_LEXCATS = {
 
 HI_LEXCATS = deepcopy(BASE_LEXCATS)
 HI_LEXCATS.add('PART')
+HI_LEXCATS.add('PRON.NOM')
+HI_LEXCATS.add('PRON.OBL') # 'koi','usi', etc
+HI_LEXCATS.add('PRON.WH') # wh-pronouns 'kahaan','kaise', etc
+HI_LEXCATS.add('PRON.REFL') # reflexive pronoun 'apna', 'ap'
+HI_LEXCATS.add('PART.FOC')
 
 ZH_LEXCATS = {
     "BA", # 把

--- a/conllulex/supersenses.py
+++ b/conllulex/supersenses.py
@@ -108,7 +108,6 @@ PSS_TREE = {
         },
         "p.Ensemble": {},
         "p.ComparisonRef": {},
-        "p.RateUnit": {},
         "p.SocialRel": {},
     },
 }

--- a/conllulex/supersenses.py
+++ b/conllulex/supersenses.py
@@ -78,9 +78,10 @@ PSS_TREE = {
         "p.Explanation": {"p.Purpose": {}},
     },
     "p.Participant": {
-        "p.Causer": {"p.Agent": {}},
-        "p.Theme": {"p.Topic": {}},
+        "p.Force": {"p.Agent": {}},
+        "p.Theme": {"p.Content":{},"p.Topic": {}},
         "p.Ancillary": {},
+        "p.Causer": {},
         "p.Stimulus": {},
         "p.Experiencer": {},
         "p.Originator": {},
@@ -91,6 +92,7 @@ PSS_TREE = {
     },
     "p.Configuration": {
         "p.Identity": {},
+        "p.SetIteration": {},
         "p.Species": {},
         "p.Gestalt": {
             "p.Possessor": {},
@@ -124,7 +126,7 @@ del queue, ss, par, descendants
 
 PSS = set(PSS_PARENTS.keys())
 
-assert len(PSS_DEPTH) == len(PSS) == 50
+assert len(PSS_DEPTH) == len(PSS) == 53
 assert max(PSS_DEPTH.values()) == 4
 assert min(PSS_DEPTH.values()) == 1
 

--- a/conllulex/supersenses.py
+++ b/conllulex/supersenses.py
@@ -125,7 +125,7 @@ del queue, ss, par, descendants
 
 PSS = set(PSS_PARENTS.keys())
 
-assert len(PSS_DEPTH) == len(PSS) == 53
+assert len(PSS_DEPTH) == len(PSS) == 52
 assert max(PSS_DEPTH.values()) == 4
 assert min(PSS_DEPTH.values()) == 1
 


### PR DESCRIPTION
Added new labels in the PSS tree for SNACS v2.6, and changed validator to handle strong MWEs with an internal goeswith relation (should not have a space in the lexlemma). 

Regressed on the Hindi LPP corpus and the STREUSLE corpus v4.5